### PR TITLE
Fix: Explicitly add MFC include directory to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ target_include_directories(SmartDesktopOrganizer PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR} # General project root
     "${CMAKE_CURRENT_SOURCE_DIR}/libs" # For nlohmann_json
     "${CMAKE_CURRENT_SOURCE_DIR}/src/mfc" # For MFC headers created in this project
+
+    # Explicitly add reported MFC include path
+    "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.40.33807/atlmfc/include"
+
     # Adding individual component directories for clarity, though ${CMAKE_CURRENT_SOURCE_DIR} might cover them
     "${CMAKE_CURRENT_SOURCE_DIR}/DesktopManager"
     "${CMAKE_CURRENT_SOURCE_DIR}/WebClassifier"


### PR DESCRIPTION
I've added the path to the MSVC atlmfc include directory that you confirmed directly into target_include_directories. This should resolve issues where MFC headers were not being found automatically, even when CMAKE_MFC_FLAG was set.