### PR TITLE
Here's a summary of the changes I've made:

### DIFF
--- a/src/mfc/MainFrm.cpp
+++ b/src/mfc/MainFrm.cpp
@@ -190,6 +190,7 @@ void CMainFrame::OnSortDesktop() {
 
     try {
         DesktopInfo dInfo; // Constructor calls CoInitializeEx
+        DesktopChecker checker; // Create a DesktopChecker instance
         // DesktopSorter's constructor creates WebClassifier, which also calls CoInitializeEx.
         // This nested CoInitializeEx is fine if they are apartment threaded and on the same thread.
         DesktopSorter dSorter;
@@ -205,19 +206,10 @@ void CMainFrame::OnSortDesktop() {
 
         ScreenMetrics screenMetrics(screenW, screenH, dpiScale);
 
-        // DesktopInfo should provide its own getDesktopPath method.
-        // Let's assume DesktopInfo has a method like getDesktopPath()
-        // If not, this part needs adjustment or DesktopChecker::getDesktopPath() could be used if static or on a dChecker instance.
-        // For now, proceeding as if dInfo.getDesktopPath() exists.
-        std::wstring desktopPath = dInfo.getDesktopPath(); // Placeholder if method doesn't exist
-        if (desktopPath.empty()) {
-            // Fallback or error if DesktopInfo doesn't provide it directly
-            DesktopChecker tempChecker; // Temporary, if DesktopInfo can't provide path
-            desktopPath = tempChecker.getDesktopPath();
-        }
 
+        std::wstring desktopPath = checker.getDesktopPath(); // Use DesktopChecker instance
         if (desktopPath.empty()) {
-            LOG_ERROR(L"CMainFrame::OnSortDesktop - Failed to get desktop path.");
+            LOG_ERROR(L"CMainFrame::OnSortDesktop - Failed to get desktop path from DesktopChecker.");
             AfxMessageBox(L"Error: Could not retrieve desktop path.", MB_OK | MB_ICONERROR);
             AfxGetApp()->DoWaitCursor(-1);
             m_wndStatusBar.SetPaneText(0, L"Sort failed: No desktop path.");

--- a/src/mfc/stdafx.cpp
+++ b/src/mfc/stdafx.cpp
@@ -1,5 +1,1 @@
-// stdafx.cpp : source file that includes just the standard includes
-// stdafx.pch will be the pre-compiled header (output name based on CMake settings)
-// stdafx.obj will contain the pre-compiled type information
-
 #include "stdafx.h"

--- a/src/mfc/stdafx.h
+++ b/src/mfc/stdafx.h
@@ -1,37 +1,22 @@
-// stdafx.h : MINIMAL include file for MFC applications
+// stdafx.h : ULTRA MINIMAL include file for MFC applications
 #pragma once
 
 #ifndef VC_EXTRALEAN
-#define VC_EXTRALEAN            // Exclude rarely-used stuff from Windows headers
+#define VC_EXTRALEAN
 #endif
 
-// Target Windows 10. This is important for API availability.
 #ifndef WINVER
-#define WINVER 0x0A00           // Windows 10
+#define WINVER 0x0A00 // Windows 10
 #endif
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0A00     // Windows 10
+#define _WIN32_WINNT 0x0A00 // Windows 10
 #endif
 
-#define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS      // some CString constructors will be explicit
-#define _AFX_ALL_WARNINGS // turns off MFC's hiding of some common and often safely ignored warning messages
+#define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS
+#define _AFX_ALL_WARNINGS
 
 #include <afxwin.h>         // MFC core and standard components
 #include <afxext.h>         // MFC extensions (CToolBar, CStatusBar)
 #include <afxdlgs.h>        // MFC dialog classes (CDialogEx)
 #include <afxcmn.h>         // MFC support for Windows Common Controls (CListCtrl)
-// #include <afxcontrolbars.h> // MFC support for ribbons and control bars - Temporarily commented
-// #include <afxdisp.h>        // MFC Automation classes - Temporarily commented
-
-// Commonly used Windows headers - Keep these minimal for now
-// #include <shlobj.h>      // For SHBrowseForFolder, shell functions - Temporarily commented
-// #include <shlwapi.h>     // For PathFileExists, other shell light-weight utilities - Temporarily commented
-// #include <wininet.h>     // For Internet functions used by WebClassifier - Temporarily commented
-
-// Standard C++ library headers - Temporarily comment out to isolate MFC/PCH issues
-// #include <vector>
-// #include <string>
-// #include <map>
-// #include <algorithm>
-// #include <memory>


### PR DESCRIPTION
- I've simplified the precompiled header (PCH) by reducing `src/mfc/stdafx.h` to a minimal set of MFC includes. This should help diagnose any PCH creation issues.
- I've ensured that `src/mfc/stdafx.cpp` only includes `stdafx.h`.
- I've corrected the `CMainFrame::OnSortDesktop` method in `MainFrm.cpp`. It now uses `DesktopChecker::getDesktopPath` instead of a non-existent `DesktopInfo` method.